### PR TITLE
Hotfix/value tuner

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -11,6 +11,8 @@ import edu.wpi.first.wpilibj.SPI;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.valuetuner.NetworkTableConstant;
+
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to
  * each mode, as described in the TimedRobot documentation. If you change the name of this class or
@@ -30,6 +32,9 @@ public class Robot extends TimedRobot {
      */
     @Override
     public void robotInit() {
+        if (debug) {
+            NetworkTableConstant.initializeAllConstants();
+        }
         m_robotContainer = new RobotContainer();
     }
 

--- a/src/main/java/frc/robot/valuetuner/NetworkTableConstant.java
+++ b/src/main/java/frc/robot/valuetuner/NetworkTableConstant.java
@@ -3,18 +3,52 @@ package frc.robot.valuetuner;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import frc.robot.Robot;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * The class is used to update the value of the web constant through the networktables.
  */
 public class NetworkTableConstant implements WebConstant {
-    private static final NetworkTable BASE_TABLE = NetworkTableInstance.getDefault().getTable("value-tuner");
+    private static final Set<NetworkTableConstant> constants = new HashSet<>();
+    private static NetworkTable BASE_TABLE = null;
+    private static boolean initializedConstants = false;
 
-    private final NetworkTableEntry constant;
+    private final String table;
+    private final String key;
     private final double defaultValue;
+    private NetworkTableEntry constant;
 
     NetworkTableConstant(String table, String key, double defaultValue) {
+        this.table = table;
+        this.key = key;
         this.defaultValue = defaultValue;
+        if (!initializedConstants) {
+            constants.add(this); // lazy initialization.
+        } else {
+            initialize();
+        }
+    }
+
+    /**
+     * Initializes all the constants.
+     * Should be used only in the {@link Robot#robotInit()} method.
+     */
+    public static void initializeAllConstants() {
+        if (!initializedConstants) {
+            BASE_TABLE = NetworkTableInstance.getDefault().getTable("value-tuner");
+            constants.forEach(NetworkTableConstant::initialize);
+            constants.clear();
+            initializedConstants = true;
+        }
+    }
+
+    /**
+     * Initialize the constant.
+     */
+    private void initialize() {
         constant = BASE_TABLE.getSubTable(table).getEntry(key);
     }
 

--- a/src/main/java/frc/robot/valuetuner/NetworkTableConstant.java
+++ b/src/main/java/frc/robot/valuetuner/NetworkTableConstant.java
@@ -50,6 +50,7 @@ public class NetworkTableConstant implements WebConstant {
      */
     private void initialize() {
         constant = BASE_TABLE.getSubTable(table).getEntry(key);
+        constant.setDouble(defaultValue);
     }
 
     /**


### PR DESCRIPTION
The problem is that we initialize the networktable before the robot is initialized (we load it when the code starts running). We need to wait until the robot loads so we can use the networktables.

The fix waits until the robot loads and then loads it before we have the robot container.
The purpose of the boolean `initializedConstants` is that after the robot initialized, then we can immediately load the constant. (the use case is for commands, that are loaded when we load the RobotContainer class)