### PR TITLE
Add commands to adjust to target while driving using various methods

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -50,7 +50,7 @@ public final class Constants {
         public static final double MODEL_TOLERANCE = 0.01;
         public static final double ENCODER_TOLERANCE = 0.01; // [ticks]
 
-        public static final double HEADING_KP = 0.1125;
+        public static final double HEADING_KP = 5;
         public static final double HEADING_KI = 1;
         public static final double HEADING_KD = 1;
         public static final TrapezoidProfile.Constraints HEADING_CONTROLLER_CONSTRAINTS = new TrapezoidProfile.Constraints(3, 1.5); // [rads/sec], [rad/sec^2]
@@ -74,6 +74,7 @@ public final class Constants {
         public static final int ANGLE_MOTION_ACCELERATION = 1300;
         public static final int ANGLE_CRUISE_VELOCITY = 400;
         public static final double DRIFTING_PERIOD = 0.2; // expected period the robot will change its rotation even after commanded to stop. [s]
+        public static final double SAMPLE_YAW_PERIOD = 0.5; // expected period the robot will change its rotation even after commanded to stop. [s]
         private static final double Rx = SwerveDrive.ROBOT_LENGTH / 2; // [m]
         private static final double Ry = SwerveDrive.ROBOT_WIDTH / 2; // [m]
         // Axis systems
@@ -85,6 +86,9 @@ public final class Constants {
         };
         // angle motion magic
         private static final float MOTION_MAGIC_SAFETY = 0.7f;
+
+        public static final double ADJUST_CONTROLLER_KP = 5;
+        public static final double ADJUST_CONTROLLER_TOLERANCE = Math.toRadians(0.5);
     }
 
     public static class Shooter {
@@ -107,6 +111,8 @@ public final class Constants {
             configuration.neutralDeadband = NEUTRAL_DEADBAND;
             return configuration;
         }
+
+        public static double CARGO_OFFSET = 3; // Desired offset from the middle of the target where you want the cargo to hit. [deg]
 
     }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -87,7 +87,8 @@ public final class Constants {
         // angle motion magic
         private static final float MOTION_MAGIC_SAFETY = 0.7f;
 
-        public static final double ADJUST_CONTROLLER_KP = 5;
+        public static final double ADJUST_CONTROLLER_KP = 15;
+        public static final double ADJUST_CONTROLLER_KI = 0.2;
         public static final double ADJUST_CONTROLLER_TOLERANCE = Math.toRadians(0.5);
     }
 
@@ -112,7 +113,7 @@ public final class Constants {
             return configuration;
         }
 
-        public static double CARGO_OFFSET = 3; // Desired offset from the middle of the target where you want the cargo to hit. [deg]
+        public static double CARGO_OFFSET = 0; // Desired offset from the middle of the target where you want the cargo to hit. [deg]
 
     }
 
@@ -182,7 +183,7 @@ public final class Constants {
     public static class Vision { //TODO: change for competition
         public static final double CAMERA_HEIGHT = 0.73; // [m]
         public static final double TARGET_HEIGHT_FROM_GROUND = 2.62; // [m]
-        public static final double CAMERA_PITCH = 33; // Pitch of the vision. [deg]
+        public static final double CAMERA_PITCH = 36.2; // Pitch of the vision. [deg]
         public static final double DIAG_FOV = 75; // Diagonal FOV. [deg]
         public static final double LED_RANGE = 6; // Visible range of LEDs. [m]
         public static final int CAM_RESOLUTION_WIDTH = 640; // Width of camera resolution. [pixel]

--- a/src/main/java/frc/robot/Ports.java
+++ b/src/main/java/frc/robot/Ports.java
@@ -89,6 +89,6 @@ public final class Ports {
     }
 
     public static class Vision {
-        public static final int LEDS = 3;
+        public static final int LEDS = 4;
     }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,23 +1,17 @@
 package frc.robot;
 
-import edu.wpi.first.wpilibj.DigitalOutput;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
-import frc.robot.commandgroups.PickUpCargo;
-import frc.robot.commandgroups.ShootCargo;
 import frc.robot.subsystems.conveyor.Conveyor;
-import frc.robot.subsystems.conveyor.commands.Convey;
 import frc.robot.subsystems.drivetrain.SwerveDrive;
-import frc.robot.subsystems.drivetrain.commands.OverpoweredDrive;
+import frc.robot.subsystems.drivetrain.commands.testing.SimpleAdjustWithVision;
 import frc.robot.subsystems.flap.Flap;
 import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.shooter.Shooter;
-import frc.robot.subsystems.shooter.commands.Shoot;
 import frc.robot.utils.PhotonVisionModule;
 import webapp.Webserver;
 
@@ -43,7 +37,7 @@ public class RobotContainer {
     //    private final Climber climber = Climber.getInstance();
     private final Hood hood = Hood.getInstance();
     private final PhotonVisionModule photonVisionModule = new PhotonVisionModule("photonvision", null);
-    private final DigitalOutput digitalOutput = new DigitalOutput(4);
+//    private final DigitalOutput digitalOutput = new DigitalOutput(4);
 
     /**
      * The container for the robot.  Contains subsystems, OI devices, and commands.
@@ -60,19 +54,19 @@ public class RobotContainer {
     }
 
     private void configureDefaultCommands() {
-        swerve.setDefaultCommand(new OverpoweredDrive(swerve, () -> -joystick.getY(), () -> -joystick.getX(), () -> -joystick2.getX()));
+        swerve.setDefaultCommand(new SimpleAdjustWithVision(swerve, () -> -joystick2.getX(), () -> rightTrigger.get(), () -> photonVisionModule.getYaw().orElse(0), () -> photonVisionModule.getDistance().orElse(0)));
 
     }
 
     private void configureButtonBindings() {
-        b.whenPressed(hood::toggle);
-        x.whenPressed(flap::toggleFlap);
-        y.whileHeld(new Convey(conveyor, -Constants.Conveyor.DEFAULT_POWER.get()));
+//        b.whenPressed(hood::toggle);
+//        x.whenPressed(flap::toggleFlap);
+//        y.whileHeld(new Convey(conveyor, -Constants.Conveyor.DEFAULT_POWER.get()));
         leftTrigger.whenPressed(() -> Robot.resetAngle());
-        rightTrigger.whenPressed(() -> digitalOutput.set(!digitalOutput.get()));
-        a.whileHeld(new Convey(conveyor, Constants.Conveyor.DEFAULT_POWER.get()));
-        trigger.whileActiveContinuous(new Shoot(
-                shooter, () -> SmartDashboard.getNumber("set_velocity", 0)));
+//        rightTrigger.whenPressed(() -> digitalOutput.set(!digitalOutput.get()));
+//        a.whileHeld(new Convey(conveyor, Constants.Conveyor.DEFAULT_POWER.get()));
+//        trigger.whileActiveContinuous(new Shoot(
+//                shooter, () -> SmartDashboard.getNumber("set_velocity", 0)));
     }
 
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -314,7 +314,6 @@ public class SwerveDrive extends SubsystemBase {
                 Robot.getAngle(),
                 getStates()
         );
-        System.out.println(getPose());
 /*
         headingController.setP(Constants.SwerveDrive.HEADING_KP.get());
         headingController.setI(Constants.SwerveDrive.HEADING_KI.get());

--- a/src/main/java/frc/robot/subsystems/drivetrain/commands/testing/SimpleAdjustWithVision.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/commands/testing/SimpleAdjustWithVision.java
@@ -1,0 +1,70 @@
+package frc.robot.subsystems.drivetrain.commands.testing;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+import frc.robot.Robot;
+import frc.robot.subsystems.drivetrain.SwerveDrive;
+import frc.robot.utils.Utils;
+
+import java.util.OptionalDouble;
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+
+public class SimpleAdjustWithVision extends CommandBase {
+    private final SwerveDrive swerveDrive;
+    private final DoubleSupplier rotationSupplier;
+    private final BooleanSupplier condition;
+    private Rotation2d target;
+    private final OptionalDouble yawSupplier;
+    private final PIDController adjustController = new PIDController(Constants.SwerveDrive.ADJUST_CONTROLLER_KP, 0, 0) {{
+        enableContinuousInput(-Math.PI, Math.PI);
+        setTolerance(Math.toRadians(Constants.SwerveDrive.ADJUST_CONTROLLER_TOLERANCE));
+    }};
+    private boolean last = false;
+    private final DoubleSupplier distanceSupplier;
+
+
+    public SimpleAdjustWithVision(SwerveDrive swerveDrive, DoubleSupplier rotationSupplier, BooleanSupplier condition, OptionalDouble yawSupplier, DoubleSupplier distanceSupplier) {
+        this.swerveDrive = swerveDrive;
+        this.rotationSupplier = rotationSupplier;
+        this.condition = condition;
+        this.yawSupplier = yawSupplier;
+        this.distanceSupplier = distanceSupplier;
+        target = Robot.getAngle();
+        addRequirements(swerveDrive);
+    }
+
+    @Override
+    public void initialize() {
+        super.initialize();
+    }
+
+    @Override
+    public void execute() {
+        double rotation = Utils.deadband(rotationSupplier.getAsDouble(), Constants.SwerveDrive.JOYSTICK_THRESHOLD);
+        if (rotation == 0 && !condition.getAsBoolean())
+            swerveDrive.terminate();
+        else {
+            if (condition.getAsBoolean()) {
+                if (!last) {
+                    Rotation2d offset = new Rotation2d(Math.atan2(Math.toRadians(-Math.signum(yawSupplier.getAsDouble()) * Constants.Shooter.CARGO_OFFSET), distanceSupplier.getAsDouble()));
+                    target = Robot.getAngle().minus(Rotation2d.fromDegrees(yawSupplier.getAsDouble()).plus(offset));
+                    rotation = adjustController.calculate(Robot.getAngle().getRadians(), target.getRadians());
+                    last = true;
+                }
+            } else {
+                last = false;
+            }
+            swerveDrive.holonomicDrive(0, 0, rotation);
+
+        }
+    }
+
+
+    @Override
+    public void end(boolean interrupted) {
+        swerveDrive.terminate();
+    }
+}

--- a/src/main/java/frc/robot/utils/PhotonVisionModule.java
+++ b/src/main/java/frc/robot/utils/PhotonVisionModule.java
@@ -143,7 +143,7 @@ public class PhotonVisionModule extends SubsystemBase {
 
     @Override
     public void periodic() {
-        System.out.println("distance= {" + (getDistance().orElse(0) + (TARGET_RADIUS)) + "}");
+//        System.out.println("distance= {" + (getDistance().orElse(0) + (TARGET_RADIUS)) + "}");
     }
 
     @Override


### PR DESCRIPTION
`DriveAndAdjustWithVision` lets you hold a button to adjust to the target based on yaw readings from the camera.

`DriveAndAdjustWithOdometry` lets you hold a button to adjust to the target based on the swerve odometry estimations (which may be tuned by the camera).

The commands use the navX to be consistent and work while driving.

`SimpleAdjustWithVision` is a simple version used to test the the logic.
