### PR TITLE
Feature/add safeties

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -136,7 +136,7 @@ public final class Constants {
             put(5.65, 4550.0);
             put(99999.0, 4550.0);
         }};
-        public static final double TARMAC_VELOCITY = 3700;
+        public static final double TARMAC_VELOCITY = 3700; // [rpm]
 
         public static TalonFXConfiguration getConfiguration() {
             final TalonFXConfiguration configuration = new TalonFXConfiguration();

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -97,6 +97,7 @@ public final class Constants {
         public static final double NEUTRAL_DEADBAND = 0.1; // [%]
         public static final double OUTPUT_MULTIPLIER = 0.1; // Multiplies the output for manual control in the bits. [%]
         public static final double OUTTAKE_POWER = 0.2; // Power to give to the shooter when taking balls out. [%]
+        public static final double LOW_GOAL_VELOCITY = 2500;
         public static final double RECOMMENDED_ACCELERATION_TIME = 1.3; // Recommended time for the shooter to get to it's setpoint. [s]
         public static final double CARGO_OFFSET = 0; // Desired offset from the middle of the target where you want the cargo to hit. [m]
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -282,7 +282,7 @@ public final class Constants {
         public static final double POWER_TO_VELOCITY_RATIO = -3 / 16.0; // Ratio of power to velocity. [% / m/s]
         public static final double TIME_BETWEEN_RUNS = 1.7; // time intake will wait before toggling the retractor (for testing only). [s]
 
-        public static final WebConstant DEFAULT_POWER = WebConstant.of("Intake", "power", 1); // power intake will receive on the basic command. [%]
+        public static final WebConstant DEFAULT_POWER = WebConstant.of("Intake", "power", 0.8); // power intake will receive on the basic command. [%]
     }
 
     public static class Hood {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -34,8 +34,8 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 public class RobotContainer {
-    public static boolean playWithoutVision = false;
-    public static boolean hardCodedVelocity = false;
+    public static final boolean playWithoutVision = false;
+    public static final boolean hardCodedVelocity = false;
 
     // The robot's subsystems and commands are defined here...
     public static LedSubsystem ledSubsystem = new LedSubsystem();
@@ -99,7 +99,7 @@ public class RobotContainer {
             }, shooter).withInterrupt(Xbox.rt::get));
             Xbox.a.whileHeld(new BackAndShootCargoSort(shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdomDistance));
+                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdometryDistance));
 
             Xbox.leftPov.whileActiveOnce(new InstantCommand(hood::toggle));
             Xbox.rightPov.whileActiveOnce(new InstantCommand(helicopter::toggleStopper));
@@ -109,7 +109,7 @@ public class RobotContainer {
             Xbox.rt.whileActiveContinuous(new BackAndShootCargo(
                     shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdomDistance));
+                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdometryDistance));
             Xbox.lt.whileActiveContinuous(new PickUpCargo(conveyor, flap, intake, Constants.Conveyor.DEFAULT_POWER.get(), Constants.Intake.DEFAULT_POWER::get));
             Xbox.lb.whileHeld(new Outtake(intake, conveyor, flap, shooter, hood, () -> false));
             Xbox.rb.whileHeld(new Convey(conveyor, -Constants.Conveyor.SHOOT_POWER));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -8,10 +8,7 @@ import edu.wpi.first.wpilibj2.command.*;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.auto.TaxiFromLowRightPickShootPickShoot;
-import frc.robot.commandgroups.BackAndShootCargoSort;
-import frc.robot.commandgroups.OneBallOuttake;
-import frc.robot.commandgroups.Outtake;
-import frc.robot.commandgroups.PickUpCargo;
+import frc.robot.commandgroups.*;
 import frc.robot.commandgroups.bits.RunAllBits;
 import frc.robot.subsystems.conveyor.Conveyor;
 import frc.robot.subsystems.conveyor.commands.Convey;
@@ -104,7 +101,7 @@ public class RobotContainer {
             Xbox.leftPov.whileActiveOnce(new InstantCommand(hood::toggle));
             Xbox.rightPov.whileActiveOnce(new InstantCommand(helicopter::toggleStopper));
             Xbox.upPov.and(Xbox.start).whileActiveOnce(new MoveHelicopter(helicopter, Constants.Helicopter.SECOND_RUNG));
-            Xbox.downPov.and(Xbox.start).whileActiveOnce(new MoveHelicopter(helicopter, 0));
+            Xbox.downPov.whileActiveOnce(new LowGoalShot(shooter, conveyor, flap, hood));
 
             Xbox.rt.whileActiveContinuous(new BackAndShootCargo(
                     shooter, hood, conveyor, flap,
@@ -120,6 +117,7 @@ public class RobotContainer {
             Xbox.rightJoystickButton
                     .whileHeld(() -> hardCodedVelocity = true)
                     .whenReleased(() -> hardCodedVelocity = false);
+
         }
 
         { // Joystick button bindings.

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 
 public class RobotContainer {
     public static final boolean playWithoutVision = false;
-    public static final boolean hardCodedVelocity = false;
+    public static final boolean hardCodedVelocity = true;
 
     // The robot's subsystems and commands are defined here...
     public static LedSubsystem ledSubsystem = new LedSubsystem();
@@ -109,7 +109,7 @@ public class RobotContainer {
             Xbox.rt.whileActiveContinuous(new BackAndShootCargo(
                     shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdometryDistance));
+                    () -> 0, photonVisionModule::hasTargets, swerve::getOdometryDistance));
             Xbox.lt.whileActiveContinuous(new PickUpCargo(conveyor, flap, intake, Constants.Conveyor.DEFAULT_POWER.get(), Constants.Intake.DEFAULT_POWER::get));
             Xbox.lb.whileHeld(new Outtake(intake, conveyor, flap, shooter, hood, () -> false));
             Xbox.rb.whileHeld(new Convey(conveyor, -Constants.Conveyor.SHOOT_POWER));
@@ -135,8 +135,8 @@ public class RobotContainer {
      * @return the command to run in autonomous
      */
     public Command getAutonomousCommand() {
-        return new RunAllBits(swerve, shooter, conveyor, intake, flap, hood, helicopter);
-//        return autonomousCommand;
+//        return new RunAllBits(swerve, shooter, conveyor, intake, flap, hood, helicopter);
+        return autonomousCommand;
     }
 
     /**

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -35,7 +35,7 @@ import java.util.function.Supplier;
 
 public class RobotContainer {
     public static final boolean playWithoutVision = false;
-    public static final boolean hardCodedVelocity = true;
+    public static boolean hardCodedVelocity = false;
 
     // The robot's subsystems and commands are defined here...
     public static LedSubsystem ledSubsystem = new LedSubsystem();
@@ -116,6 +116,10 @@ public class RobotContainer {
 
             Xbox.start.whenPressed(photonVisionModule::toggleLeds);
             Xbox.back.whenPressed(new OneBallOuttake(intake, conveyor, () -> conveyor.getColorSensorProximity() >= 150));
+
+            Xbox.rightJoystickButton
+                    .whileHeld(() -> hardCodedVelocity = true)
+                    .whenReleased(() -> hardCodedVelocity = false);
         }
 
         { // Joystick button bindings.
@@ -184,5 +188,7 @@ public class RobotContainer {
         public static final Trigger downPov = new Trigger(() -> controller.getPOV() == 180);
         public static final Trigger rightPov = new Trigger(() -> controller.getPOV() == 90);
         public static final Trigger leftPov = new Trigger(() -> controller.getPOV() == 270);
+
+        public static final JoystickButton rightJoystickButton = new JoystickButton(controller, XboxController.Button.kRightStick.value);
     }
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -76,7 +76,7 @@ public class RobotContainer {
                         () -> photonVisionModule.getYaw().orElse(0),
                         Joysticks.rightTrigger::get,
                         photonVisionModule::getDistance,
-                        () -> photonVisionModule.hasTargets())
+                        photonVisionModule::hasTargets)
         );
         helicopter.setDefaultCommand(new JoystickPowerHelicopter(helicopter, Xbox.controller::getLeftY));
     }
@@ -99,7 +99,7 @@ public class RobotContainer {
             }, shooter).withInterrupt(Xbox.rt::get));
             Xbox.a.whileHeld(new BackAndShootCargoSort(shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget, () -> photonVisionModule.hasTargets(), () -> swerve.getOdomDistance()));
+                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdomDistance));
 
             Xbox.leftPov.whileActiveOnce(new InstantCommand(hood::toggle));
             Xbox.rightPov.whileActiveOnce(new InstantCommand(helicopter::toggleStopper));
@@ -109,7 +109,7 @@ public class RobotContainer {
             Xbox.rt.whileActiveContinuous(new BackAndShootCargo(
                     shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget, () -> photonVisionModule.hasTargets(), () -> swerve.getOdomDistance()));
+                    distanceFromTarget, photonVisionModule::hasTargets, swerve::getOdomDistance));
             Xbox.lt.whileActiveContinuous(new PickUpCargo(conveyor, flap, intake, Constants.Conveyor.DEFAULT_POWER.get(), Constants.Intake.DEFAULT_POWER::get));
             Xbox.lb.whileHeld(new Outtake(intake, conveyor, flap, shooter, hood, () -> false));
             Xbox.rb.whileHeld(new Convey(conveyor, -Constants.Conveyor.SHOOT_POWER));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -18,7 +18,6 @@ import frc.robot.subsystems.drivetrain.commands.TurnToAngle;
 import frc.robot.subsystems.flap.Flap;
 import frc.robot.subsystems.helicopter.Helicopter;
 import frc.robot.subsystems.helicopter.commands.JoystickPowerHelicopter;
-import frc.robot.subsystems.helicopter.commands.MoveHelicopter;
 import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.intake.Intake;
 import frc.robot.subsystems.shooter.Shooter;
@@ -100,7 +99,7 @@ public class RobotContainer {
 
             Xbox.leftPov.whileActiveOnce(new InstantCommand(hood::toggle));
             Xbox.rightPov.whileActiveOnce(new InstantCommand(helicopter::toggleStopper));
-            Xbox.upPov.and(Xbox.start).whileActiveOnce(new MoveHelicopter(helicopter, Constants.Helicopter.SECOND_RUNG));
+            Xbox.upPov.whileActiveOnce(new SafetyShootCargo(shooter, conveyor, flap, hood, distanceFromTarget));
             Xbox.downPov.whileActiveOnce(new LowGoalShot(shooter, conveyor, flap, hood));
 
             Xbox.rt.whileActiveContinuous(new BackAndShootCargo(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -107,7 +107,7 @@ public class RobotContainer {
             }, shooter).withInterrupt(Xbox.rt::get));
             Xbox.a.whileHeld(new BackAndShootCargoSort(shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget));
+                    distanceFromTarget, () -> photonVisionModule.hasTargets(), () -> swerve.getOdomDistance()));
 
             Xbox.leftPov.whileActiveOnce(new InstantCommand(hood::toggle));
             Xbox.rightPov.whileActiveOnce(new InstantCommand(helicopter::toggleStopper));
@@ -117,7 +117,7 @@ public class RobotContainer {
             Xbox.rt.whileActiveContinuous(new BackAndShootCargo(
                     shooter, hood, conveyor, flap,
                     () -> Constants.Conveyor.SHOOT_POWER,
-                    distanceFromTarget));
+                    distanceFromTarget, () -> photonVisionModule.hasTargets(), () -> swerve.getOdomDistance()));
             Xbox.lt.whileActiveContinuous(new PickUpCargo(conveyor, flap, intake, Constants.Conveyor.DEFAULT_POWER.get(), Constants.Intake.DEFAULT_POWER::get));
             Xbox.lb.whileHeld(new Outtake(intake, conveyor, flap, shooter, hood, () -> false));
             Xbox.rb.whileHeld(new Convey(conveyor, -Constants.Conveyor.SHOOT_POWER));

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,7 +1,6 @@
 package frc.robot;
 
 import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.XboxController;
@@ -35,6 +34,7 @@ import java.util.function.DoubleSupplier;
 import java.util.function.Supplier;
 
 public class RobotContainer {
+    public static boolean playWithoutVision = false;
 
     // The robot's subsystems and commands are defined here...
     public static LedSubsystem ledSubsystem = new LedSubsystem();
@@ -66,25 +66,16 @@ public class RobotContainer {
     }
 
     private void configureDefaultCommands() {
-        Supplier<Pose2d> swervePose = swerve::getPose;
-        Supplier<Transform2d> poseRelativeToTarget = () -> Constants.Vision.HUB_POSE.minus(swervePose.get());
-        DoubleSupplier yaw = () -> photonVisionModule.getYaw().orElse(Robot.getAngle().minus(new Rotation2d(
-                        Math.atan2(
-                                poseRelativeToTarget.get().getY(),
-                                poseRelativeToTarget.get().getX()
-                        )
-                )
-        ).getDegrees());
         swerve.setDefaultCommand(
                 new DriveAndAdjustWithVision(
                         swerve,
                         () -> -Joysticks.leftJoystick.getY() * speedMultiplier,
                         () -> -Joysticks.leftJoystick.getX() * speedMultiplier,
                         () -> -Joysticks.rightJoystick.getX() * thetaMultiplier,
-                        yaw,
+                        () -> photonVisionModule.getYaw().orElse(0),
                         Joysticks.rightTrigger::get,
-                        photonVisionModule::getDistance
-                )
+                        photonVisionModule::getDistance,
+                        () -> photonVisionModule.hasTargets())
         );
         helicopter.setDefaultCommand(new JoystickPowerHelicopter(helicopter, Xbox.controller::getLeftY));
     }

--- a/src/main/java/frc/robot/auto/SaarIsAutonomous.java
+++ b/src/main/java/frc/robot/auto/SaarIsAutonomous.java
@@ -89,7 +89,9 @@ public class SaarIsAutonomous extends SequentialCommandGroup {
                         conveyor,
                         flap,
                         conveyorPower,
-                        distanceFromTarget)
+                        distanceFromTarget,
+                        () -> visionModule.hasTargets(),
+                        () -> swerveDrive.getOdomDistance())
                         .withTimeout(timeout),
                         new IntakeCargo(intake, Constants.Intake.DEFAULT_POWER::get),
                         new SimpleAdjustWithVision(swerveDrive, () -> 0, () -> true, yaw, distanceFromTarget))

--- a/src/main/java/frc/robot/auto/SaarIsAutonomous.java
+++ b/src/main/java/frc/robot/auto/SaarIsAutonomous.java
@@ -11,8 +11,8 @@ import frc.robot.Robot;
 import frc.robot.commandgroups.PickUpCargo;
 import frc.robot.subsystems.conveyor.Conveyor;
 import frc.robot.subsystems.drivetrain.SwerveDrive;
+import frc.robot.subsystems.drivetrain.commands.AdjustToTargetOnCommand;
 import frc.robot.subsystems.drivetrain.commands.auto.FollowPath;
-import frc.robot.subsystems.drivetrain.commands.testing.SimpleAdjustWithVision;
 import frc.robot.subsystems.flap.Flap;
 import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.intake.Intake;
@@ -82,7 +82,7 @@ public class SaarIsAutonomous extends SequentialCommandGroup {
                 )
         ).getDegrees());
         return new SequentialCommandGroup(
-                new SimpleAdjustWithVision(swerveDrive, () -> 0, () -> true, yaw, distanceFromTarget).withTimeout(0.3),
+                new AdjustToTargetOnCommand(swerveDrive, () -> visionModule.getYaw().orElse(0), () -> visionModule.hasTargets()).withTimeout(0.3),
                 new ParallelRaceGroup(new BackAndShootCargo(
                         shooter,
                         hood,
@@ -92,7 +92,7 @@ public class SaarIsAutonomous extends SequentialCommandGroup {
                         distanceFromTarget)
                         .withTimeout(timeout),
                         new IntakeCargo(intake, Constants.Intake.DEFAULT_POWER::get),
-                        new SimpleAdjustWithVision(swerveDrive, () -> 0, () -> true, yaw, distanceFromTarget))
+                        new AdjustToTargetOnCommand(swerveDrive, () -> visionModule.getYaw().orElse(0), () -> visionModule.hasTargets()))
         );
     }
 

--- a/src/main/java/frc/robot/auto/SaarIsAutonomous.java
+++ b/src/main/java/frc/robot/auto/SaarIsAutonomous.java
@@ -91,7 +91,7 @@ public class SaarIsAutonomous extends SequentialCommandGroup {
                         conveyorPower,
                         distanceFromTarget,
                         () -> visionModule.hasTargets(),
-                        () -> swerveDrive.getOdomDistance())
+                        () -> swerveDrive.getOdometryDistance())
                         .withTimeout(timeout),
                         new IntakeCargo(intake, Constants.Intake.DEFAULT_POWER::get),
                         new AdjustToTargetOnCommand(swerveDrive, () -> visionModule.getYaw().orElse(0), () -> visionModule.hasTargets()))

--- a/src/main/java/frc/robot/commandgroups/BackAndShootCargoSort.java
+++ b/src/main/java/frc/robot/commandgroups/BackAndShootCargoSort.java
@@ -16,8 +16,8 @@ public class BackAndShootCargoSort extends SequentialCommandGroup {
                                  Conveyor conveyor,
                                  Flap flap,
                                  DoubleSupplier conveyorPower,
-                                 DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+                                 DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         addCommands(new Convey(conveyor, -0.25).withTimeout(0.075).withInterrupt(conveyor::isPreFlapBeamConnected),
-                new ShootCargo2(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, hasTarget, odomDistance));
+                new ShootCargo2(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, hasTarget, odometryDistance));
     }
 }

--- a/src/main/java/frc/robot/commandgroups/BackAndShootCargoSort.java
+++ b/src/main/java/frc/robot/commandgroups/BackAndShootCargoSort.java
@@ -7,6 +7,7 @@ import frc.robot.subsystems.flap.Flap;
 import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.shooter.Shooter;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 public class BackAndShootCargoSort extends SequentialCommandGroup {
@@ -15,8 +16,8 @@ public class BackAndShootCargoSort extends SequentialCommandGroup {
                                  Conveyor conveyor,
                                  Flap flap,
                                  DoubleSupplier conveyorPower,
-                                 DoubleSupplier distanceFromTarget) {
+                                 DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
         addCommands(new Convey(conveyor, -0.25).withTimeout(0.075).withInterrupt(conveyor::isPreFlapBeamConnected),
-                new ShootCargo2(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget));
+                new ShootCargo2(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, hasTarget, odomDistance));
     }
 }

--- a/src/main/java/frc/robot/commandgroups/LowGoalShot.java
+++ b/src/main/java/frc/robot/commandgroups/LowGoalShot.java
@@ -1,0 +1,22 @@
+package frc.robot.commandgroups;
+
+import edu.wpi.first.wpilibj2.command.*;
+import frc.robot.Constants;
+import frc.robot.subsystems.conveyor.Conveyor;
+import frc.robot.subsystems.conveyor.commands.Convey;
+import frc.robot.subsystems.flap.Flap;
+import frc.robot.subsystems.hood.Hood;
+import frc.robot.subsystems.shooter.Shooter;
+import frc.robot.utils.Utils;
+
+public class LowGoalShot extends ParallelCommandGroup {
+
+    public LowGoalShot(Shooter shooter, Conveyor conveyor, Flap flap, Hood hood) {
+
+        addCommands(
+                new InstantCommand(() -> hood.setSolenoid(Hood.Mode.ShortDistance)),
+                new InstantCommand(flap::allowShooting),
+                new RunCommand(() -> shooter.setVelocity(Constants.Shooter.LOW_GOAL_VELOCITY))
+        );
+    }
+}

--- a/src/main/java/frc/robot/commandgroups/Outtake.java
+++ b/src/main/java/frc/robot/commandgroups/Outtake.java
@@ -27,7 +27,7 @@ public class Outtake extends ParallelCommandGroup {
                 new Convey(conveyor, () -> Constants.Conveyor.DEFAULT_POWER.get() * (condition.getAsBoolean() ? 1 : -1)),
                 new DynamicConditionalCommand(
                         condition,
-                        new Shoot(shooter, hood, Constants.Shooter.OUTTAKE_POWER),
+                        new Shoot(shooter, hood, Constants.Shooter.OUTTAKE_POWER, hasTarget, odomDistance),
                         new IntakeCargo(intake, () -> -Constants.Intake.DEFAULT_POWER.get())
                 )
         );

--- a/src/main/java/frc/robot/commandgroups/SafetyShootCargo.java
+++ b/src/main/java/frc/robot/commandgroups/SafetyShootCargo.java
@@ -1,0 +1,30 @@
+package frc.robot.commandgroups;
+
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import frc.robot.Constants;
+import frc.robot.subsystems.conveyor.Conveyor;
+import frc.robot.subsystems.conveyor.commands.Convey;
+import frc.robot.subsystems.flap.Flap;
+import frc.robot.subsystems.hood.Hood;
+import frc.robot.subsystems.shooter.Shooter;
+import frc.robot.subsystems.shooter.commands.Shoot;
+import frc.robot.subsystems.shooter.commands.WarmUpShooter;
+import frc.robot.utils.Utils;
+
+import java.util.function.DoubleSupplier;
+
+public class SafetyShootCargo extends ParallelCommandGroup {
+
+    public SafetyShootCargo(Shooter shooter, Conveyor conveyor, Flap flap, Hood hood, DoubleSupplier distanceFromTarget) {
+        addCommands(
+                new InstantCommand(flap::allowShooting),
+                new InstantCommand(() -> hood.setSolenoid(Hood.Mode.getValue(distanceFromTarget.getAsDouble() < Constants.Hood.DISTANCE_FROM_TARGET_THRESHOLD))),
+                new WarmUpShooter(shooter, distanceFromTarget),
+                new Convey(conveyor, Constants.Conveyor.SHOOT_POWER,
+                        () -> Utils.conventionalDeadband(
+                                shooter.getVelocity() - Shoot.getSetpointVelocity(
+                                        distanceFromTarget.getAsDouble()), Constants.Shooter.SHOOTER_VELOCITY_DEADBAND.get()) == 0)
+        );
+    }
+}

--- a/src/main/java/frc/robot/commandgroups/ShootCargo.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo.java
@@ -2,6 +2,8 @@ package frc.robot.commandgroups;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
+import frc.robot.Constants;
+import frc.robot.RobotContainer;
 import frc.robot.subsystems.conveyor.Conveyor;
 import frc.robot.subsystems.conveyor.commands.Convey3;
 import frc.robot.subsystems.flap.Flap;
@@ -25,8 +27,8 @@ public class ShootCargo extends ParallelCommandGroup {
         DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble());
 
         addCommands(
-                new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
-                new Convey3(conveyor, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity),
+                new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), RobotContainer.hardCodedVelocity ? () -> 3.6 : distanceFromTarget, hasTarget, odometryDistance),
+                new Convey3(conveyor, () -> !conveyor.isPreFlapBeamConnected(), RobotContainer.hardCodedVelocity ? () -> Constants.Shooter.TARMAC_VELOCITY : setpointVelocity, shooter::getVelocity),
                 new InstantCommand(flap::allowShooting),
                 new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odometryDistance)
         );

--- a/src/main/java/frc/robot/commandgroups/ShootCargo.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo.java
@@ -13,8 +13,6 @@ import frc.robot.subsystems.shooter.commands.Shoot;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
-import static frc.robot.Constants.Shooter.SHOOTER_VELOCITY_DEADBAND;
-
 public class ShootCargo extends ParallelCommandGroup {
 
     public ShootCargo(Shooter shooter,
@@ -23,15 +21,14 @@ public class ShootCargo extends ParallelCommandGroup {
                       Flap flap,
                       DoubleSupplier conveyorPower,
                       DoubleSupplier distanceFromTarget,
-                      boolean bool) {
-        DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble(), hood.isOpen());
-        BooleanSupplier isFlywheelAtSetpoint = () -> Math.abs(setpointVelocity.getAsDouble() - shooter.getVelocity()) < SHOOTER_VELOCITY_DEADBAND.get();
+                      boolean bool, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+        DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble());
 
         addCommands(
                 new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
                 new Convey3(conveyor, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity),
                 new InstantCommand(flap::allowShooting),
-                new Shoot(shooter, hood, distanceFromTarget, bool)
+                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odomDistance)
         );
     }
 
@@ -40,7 +37,7 @@ public class ShootCargo extends ParallelCommandGroup {
                       Conveyor conveyor,
                       Flap flap,
                       DoubleSupplier conveyorPower,
-                      DoubleSupplier distanceFromTarget) {
-        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true);
+                      DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true, hasTarget, odomDistance);
     }
 }

--- a/src/main/java/frc/robot/commandgroups/ShootCargo.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo.java
@@ -21,14 +21,14 @@ public class ShootCargo extends ParallelCommandGroup {
                       Flap flap,
                       DoubleSupplier conveyorPower,
                       DoubleSupplier distanceFromTarget,
-                      boolean bool, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+                      boolean bool, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble());
 
         addCommands(
                 new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
                 new Convey3(conveyor, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity),
                 new InstantCommand(flap::allowShooting),
-                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odomDistance)
+                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odometryDistance)
         );
     }
 
@@ -37,7 +37,7 @@ public class ShootCargo extends ParallelCommandGroup {
                       Conveyor conveyor,
                       Flap flap,
                       DoubleSupplier conveyorPower,
-                      DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
-        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true, hasTarget, odomDistance);
+                      DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
+        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true, hasTarget, odometryDistance);
     }
 }

--- a/src/main/java/frc/robot/commandgroups/ShootCargo.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo.java
@@ -10,10 +10,7 @@ import frc.robot.subsystems.hood.commands.HoodCommand;
 import frc.robot.subsystems.shooter.Shooter;
 import frc.robot.subsystems.shooter.commands.Shoot;
 
-import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
-
-import static frc.robot.Constants.Shooter.SHOOTER_VELOCITY_DEADBAND;
 
 public class ShootCargo extends ParallelCommandGroup {
 
@@ -25,13 +22,12 @@ public class ShootCargo extends ParallelCommandGroup {
                       DoubleSupplier distanceFromTarget,
                       boolean bool) {
         DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble(), hood.isOpen());
-        BooleanSupplier isFlywheelAtSetpoint = () -> Math.abs(setpointVelocity.getAsDouble() - shooter.getVelocity()) < SHOOTER_VELOCITY_DEADBAND.get();
 
         addCommands(
                 new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
                 new Convey3(conveyor, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity),
                 new InstantCommand(flap::allowShooting),
-                new Shoot(shooter, hood, distanceFromTarget, bool)
+                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget)
         );
     }
 

--- a/src/main/java/frc/robot/commandgroups/ShootCargo2.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo2.java
@@ -22,15 +22,15 @@ public class ShootCargo2 extends ParallelCommandGroup {
                        Flap flap,
                        DoubleSupplier conveyorPower,
                        DoubleSupplier distanceFromTarget,
-                       boolean bool) {
-        DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble(), hood.isOpen());
+                       boolean bool, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+        DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble());
         BooleanSupplier isFlywheelAtSetpoint = () -> Math.abs(setpointVelocity.getAsDouble() - shooter.getVelocity()) < SHOOTER_VELOCITY_DEADBAND.get();
 
         addCommands(
 //                new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
                 new Convey4(conveyor, hood, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity, distanceFromTarget),
                 new InstantCommand(flap::allowShooting),
-                new Shoot(shooter, hood, distanceFromTarget, bool)
+                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odomDistance)
         );
     }
 
@@ -39,7 +39,7 @@ public class ShootCargo2 extends ParallelCommandGroup {
                        Conveyor conveyor,
                        Flap flap,
                        DoubleSupplier conveyorPower,
-                       DoubleSupplier distanceFromTarget) {
-        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true);
+                       DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true, hasTarget, odomDistance);
     }
 }

--- a/src/main/java/frc/robot/commandgroups/ShootCargo2.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo2.java
@@ -30,7 +30,7 @@ public class ShootCargo2 extends ParallelCommandGroup {
 //                new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
                 new Convey4(conveyor, hood, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity, distanceFromTarget),
                 new InstantCommand(flap::allowShooting),
-                new Shoot(shooter, hood, distanceFromTarget, bool)
+                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget)
         );
     }
 

--- a/src/main/java/frc/robot/commandgroups/ShootCargo2.java
+++ b/src/main/java/frc/robot/commandgroups/ShootCargo2.java
@@ -22,7 +22,7 @@ public class ShootCargo2 extends ParallelCommandGroup {
                        Flap flap,
                        DoubleSupplier conveyorPower,
                        DoubleSupplier distanceFromTarget,
-                       boolean bool, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+                       boolean bool, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         DoubleSupplier setpointVelocity = () -> Shoot.getSetpointVelocity(distanceFromTarget.getAsDouble());
         BooleanSupplier isFlywheelAtSetpoint = () -> Math.abs(setpointVelocity.getAsDouble() - shooter.getVelocity()) < SHOOTER_VELOCITY_DEADBAND.get();
 
@@ -30,7 +30,7 @@ public class ShootCargo2 extends ParallelCommandGroup {
 //                new HoodCommand(hood, () -> !conveyor.isPostFlapBeamConnected(), distanceFromTarget),
                 new Convey4(conveyor, hood, () -> !conveyor.isPreFlapBeamConnected(), setpointVelocity, shooter::getVelocity, distanceFromTarget),
                 new InstantCommand(flap::allowShooting),
-                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odomDistance)
+                new Shoot(shooter, hood, distanceFromTarget, bool, hasTarget, odometryDistance)
         );
     }
 
@@ -39,7 +39,7 @@ public class ShootCargo2 extends ParallelCommandGroup {
                        Conveyor conveyor,
                        Flap flap,
                        DoubleSupplier conveyorPower,
-                       DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
-        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true, hasTarget, odomDistance);
+                       DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
+        this(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, true, hasTarget, odometryDistance);
     }
 }

--- a/src/main/java/frc/robot/commandgroups/bits/TestBallFlow.java
+++ b/src/main/java/frc/robot/commandgroups/bits/TestBallFlow.java
@@ -26,7 +26,7 @@ public class TestBallFlow extends SequentialCommandGroup {
         this.intake = intake;
         this.shooter = shooter;
         this.conveyor = conveyor;
-        this.shootCargo = new ShootCargo(shooter, hood, conveyor, flap, () -> 8, Constants.Conveyor.DEFAULT_POWER::get);
+        this.shootCargo = new ShootCargo(shooter, hood, conveyor, flap, () -> 8, Constants.Conveyor.DEFAULT_POWER::get, () -> true, () -> 0);
         this.pickUpCargo = new PickUpCargo(conveyor, flap, intake, Constants.Conveyor.DEFAULT_POWER.get(), () -> 0.5);
 
         addCommands(

--- a/src/main/java/frc/robot/subsystems/conveyor/commands/Convey3.java
+++ b/src/main/java/frc/robot/subsystems/conveyor/commands/Convey3.java
@@ -23,10 +23,10 @@ public class Convey3 extends CommandBase {
     private double setpoint = 0;
     private boolean wait = true;
 
-    public Convey3(Conveyor conveyor, BooleanSupplier preFlapSupplier, DoubleSupplier distanceSupplier, DoubleSupplier velocitySupplier) {
+    public Convey3(Conveyor conveyor, BooleanSupplier preFlapSupplier, DoubleSupplier setpointSupplier, DoubleSupplier velocitySupplier) {
         this.conveyor = conveyor;
         this.preFlapSupplier = preFlapSupplier;
-        this.setpointSuppier = distanceSupplier;
+        this.setpointSuppier = setpointSupplier;
         this.velocitySupplier = velocitySupplier;
         addRequirements(conveyor);
     }

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -342,6 +342,10 @@ public class SwerveDrive extends SubsystemBase {
         modules[1].setAngle(Rotation2d.fromDegrees(-45));
     }
 
+    public double getOdomDistance() {
+        return Constants.Vision.HUB_POSE.getTranslation().minus(getPose().getTranslation()).getNorm();
+    }
+
     @Override
     public void periodic() {
         odometry.updateWithTime(

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -377,6 +377,7 @@ public class SwerveDrive extends SubsystemBase {
 //        SmartDashboard.putString("robot_position", outputPosition);
         String outputRotation = String.valueOf(Robot.getAngle().getDegrees());
         SmartDashboard.putString("robot_rotation", outputRotation);
+        System.out.println("distance: " + getOdometryDistance());
 
 
     }

--- a/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/SwerveDrive.java
@@ -342,7 +342,12 @@ public class SwerveDrive extends SubsystemBase {
         modules[1].setAngle(Rotation2d.fromDegrees(-45));
     }
 
-    public double getOdomDistance() {
+    /**
+     * Get the distance of the robot from the hub using odometry.
+     *
+     * @return distance from hub. [m]
+     */
+    public double getOdometryDistance() {
         return Constants.Vision.HUB_POSE.getTranslation().minus(getPose().getTranslation()).getNorm();
     }
 

--- a/src/main/java/frc/robot/subsystems/drivetrain/commands/AdjustToTargetOnCommand.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/commands/AdjustToTargetOnCommand.java
@@ -36,12 +36,11 @@ public class AdjustToTargetOnCommand extends CommandBase {
             var robotPose = swerveDrive.getPose().getTranslation();
             var hubPose = Constants.Vision.HUB_POSE.getTranslation();
             var poseRelativeToTarget = hubPose.minus(robotPose);
-            var value = robotAngle.plus(new Rotation2d(
+            target = robotAngle.plus(new Rotation2d(
                     Math.atan2(
                             poseRelativeToTarget.getY(),
                             poseRelativeToTarget.getX()
                     )));
-            target = value;
         } else {
             target = Robot.getAngle().minus(Rotation2d.fromDegrees(yawSupplier.getAsDouble()));
         }

--- a/src/main/java/frc/robot/subsystems/drivetrain/commands/AdjustToTargetOnCommand.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/commands/AdjustToTargetOnCommand.java
@@ -1,0 +1,61 @@
+package frc.robot.subsystems.drivetrain.commands;
+
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Constants;
+import frc.robot.Robot;
+import frc.robot.subsystems.drivetrain.SwerveDrive;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.DoubleSupplier;
+
+public class AdjustToTargetOnCommand extends CommandBase {
+    private final SwerveDrive swerveDrive;
+    private final DoubleSupplier yawSupplier;
+    private final PIDController adjustController = new PIDController(Constants.SwerveDrive.ADJUST_CONTROLLER_KP.get(), 0, 0) {{
+        enableContinuousInput(-Math.PI, Math.PI);
+        setTolerance(Constants.SwerveDrive.ADJUST_CONTROLLER_TOLERANCE);
+    }};
+    private final BooleanSupplier hasTarget;
+    private Rotation2d target;
+
+
+    public AdjustToTargetOnCommand(SwerveDrive swerveDrive, DoubleSupplier yawSupplier, BooleanSupplier hasTarget) {
+        this.swerveDrive = swerveDrive;
+        this.yawSupplier = yawSupplier;
+        this.hasTarget = hasTarget;
+        target = Robot.getAngle();
+        addRequirements(swerveDrive);
+    }
+
+    @Override
+    public void initialize() {
+        if (!hasTarget.getAsBoolean()) {
+            var robotAngle = Robot.getAngle();
+            var robotPose = swerveDrive.getPose().getTranslation();
+            var hubPose = Constants.Vision.HUB_POSE.getTranslation();
+            var poseRelativeToTarget = hubPose.minus(robotPose);
+            var value = robotAngle.plus(new Rotation2d(
+                    Math.atan2(
+                            poseRelativeToTarget.getY(),
+                            poseRelativeToTarget.getX()
+                    )));
+            target = value;
+        } else {
+            target = Robot.getAngle().minus(Rotation2d.fromDegrees(yawSupplier.getAsDouble()));
+        }
+    }
+
+    @Override
+    public void execute() {
+        double rotation = adjustController.calculate(Robot.getAngle().getRadians(), target.getRadians());
+        swerveDrive.holonomicDrive(0, 0, rotation);
+    }
+
+
+    @Override
+    public void end(boolean interrupted) {
+        swerveDrive.terminate();
+    }
+}

--- a/src/main/java/frc/robot/subsystems/drivetrain/commands/DriveAndAdjustWithVision.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/commands/DriveAndAdjustWithVision.java
@@ -96,11 +96,11 @@ public class DriveAndAdjustWithVision extends HolonomicDrive {
                     var robotPose = swerveDrive.getPose().getTranslation();
                     var hubPose = Constants.Vision.HUB_POSE.getTranslation();
                     var poseRelativeToTarget = hubPose.minus(robotPose);
-                    var value = robotAngle.plus(new Rotation2d(
+                    var value = new Rotation2d(
                             Math.atan2(
                                     poseRelativeToTarget.getY(),
                                     poseRelativeToTarget.getX()
-                            )));
+                            ));
                     target = value;
                 } else {
                     if (sampleYawTimer.hasElapsed(Constants.SwerveDrive.SAMPLE_YAW_PERIOD)) {

--- a/src/main/java/frc/robot/subsystems/drivetrain/commands/DriveAndAdjustWithVisionExperimental.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/commands/DriveAndAdjustWithVisionExperimental.java
@@ -97,11 +97,11 @@ public class DriveAndAdjustWithVisionExperimental extends HolonomicDrive {
                         var robotPose = swerveDrive.getPose().getTranslation();
                         var hubPose = Constants.Vision.HUB_POSE.getTranslation();
                         var poseRelativeToTarget = hubPose.minus(robotPose);
-                        var value = robotAngle.plus(new Rotation2d(
+                        var value = new Rotation2d(
                                 Math.atan2(
                                         poseRelativeToTarget.getY(),
                                         poseRelativeToTarget.getX()
-                                )));
+                                ));
                         target = value;
                     } else {
                         target = Robot.getAngle().minus(Rotation2d.fromDegrees(yawSupplier.getAsDouble()));

--- a/src/main/java/frc/robot/subsystems/hood/commands/HoodCommand.java
+++ b/src/main/java/frc/robot/subsystems/hood/commands/HoodCommand.java
@@ -14,13 +14,17 @@ public class HoodCommand extends CommandBase {
     private final DoubleSupplier distance;
     private final Timer timer = new Timer();
     private final boolean last = false;
+    private final BooleanSupplier hasTarget;
+    private final DoubleSupplier odometryDistance;
     private Hood.Mode mode = Hood.Mode.ShortDistance;
     private boolean starting = true;
 
-    public HoodCommand(Hood hood, BooleanSupplier postFlap, DoubleSupplier distance) {
+    public HoodCommand(Hood hood, BooleanSupplier postFlap, DoubleSupplier distance, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         this.hood = hood;
         this.postFlap = postFlap;
         this.distance = distance;
+        this.hasTarget = hasTarget;
+        this.odometryDistance = odometryDistance;
         addRequirements(hood);
     }
 
@@ -28,7 +32,11 @@ public class HoodCommand extends CommandBase {
     public void initialize() {
         timer.reset();
         timer.start();
-        mode = distance.getAsDouble() < Constants.Hood.DISTANCE_FROM_TARGET_THRESHOLD ? Hood.Mode.ShortDistance : Hood.Mode.LongDistance;
+        if (hasTarget.getAsBoolean()) {
+            mode = distance.getAsDouble() < Constants.Hood.DISTANCE_FROM_TARGET_THRESHOLD ? Hood.Mode.ShortDistance : Hood.Mode.LongDistance;
+        } else {
+            mode = odometryDistance.getAsDouble() < Constants.Hood.DISTANCE_FROM_TARGET_THRESHOLD ? Hood.Mode.ShortDistance : Hood.Mode.LongDistance;
+        }
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/commands/BackAndShootCargo.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/BackAndShootCargo.java
@@ -8,6 +8,7 @@ import frc.robot.subsystems.flap.Flap;
 import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.shooter.Shooter;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 public class BackAndShootCargo extends SequentialCommandGroup {
@@ -16,9 +17,9 @@ public class BackAndShootCargo extends SequentialCommandGroup {
                              Conveyor conveyor,
                              Flap flap,
                              DoubleSupplier conveyorPower,
-                             DoubleSupplier distanceFromTarget) {
+                             DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
         addCommands(new Convey(conveyor, -0.25).withTimeout(0.075).withInterrupt(conveyor::isPreFlapBeamConnected),
-                new ShootCargo(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget));
+                new ShootCargo(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, hasTarget, odomDistance));
 
 
     }

--- a/src/main/java/frc/robot/subsystems/shooter/commands/BackAndShootCargo.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/BackAndShootCargo.java
@@ -17,9 +17,9 @@ public class BackAndShootCargo extends SequentialCommandGroup {
                              Conveyor conveyor,
                              Flap flap,
                              DoubleSupplier conveyorPower,
-                             DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+                             DoubleSupplier distanceFromTarget, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         addCommands(new Convey(conveyor, -0.25).withTimeout(0.075).withInterrupt(conveyor::isPreFlapBeamConnected),
-                new ShootCargo(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, hasTarget, odomDistance));
+                new ShootCargo(shooter, hood, conveyor, flap, conveyorPower, distanceFromTarget, hasTarget, odometryDistance));
 
 
     }

--- a/src/main/java/frc/robot/subsystems/shooter/commands/Shoot.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/Shoot.java
@@ -23,33 +23,33 @@ public class Shoot extends CommandBase {
     private final OptionalDouble power;
     private final Timer timer = new Timer();
     private final BooleanSupplier hasTarget;
-    private final DoubleSupplier odomDistance;
+    private final DoubleSupplier odometryDistance;
     private double setpointVelocity = 0;
 
-    public Shoot(Shooter shooter, Hood hood, double power, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+    public Shoot(Shooter shooter, Hood hood, double power, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         this.shooter = shooter;
         this.hood = hood;
         this.hasTarget = () -> true;
-        this.odomDistance = () -> 0;
+        this.odometryDistance = () -> 0;
         this.distance = () -> 8;
         this.power = OptionalDouble.of(power);
         bool = false;
         addRequirements(shooter);
     }
 
-    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, boolean bool, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, boolean bool, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
         this.shooter = shooter;
         this.hood = hood;
         this.distance = distance;
         this.bool = bool;
         this.hasTarget = hasTarget;
-        this.odomDistance = odomDistance;
+        this.odometryDistance = odometryDistance;
         this.power = OptionalDouble.empty();
         addRequirements(shooter);
     }
 
-    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
-        this(shooter, hood, distance, false, hasTarget, odomDistance);
+    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, BooleanSupplier hasTarget, DoubleSupplier odometryDistance) {
+        this(shooter, hood, distance, false, hasTarget, odometryDistance);
     }
 
     /**
@@ -99,7 +99,7 @@ public class Shoot extends CommandBase {
             if (hasTarget.getAsBoolean()) {
                 setpointVelocity = getSetpointVelocity(distance.getAsDouble());
             } else {
-                setpointVelocity = getSetpointVelocity(odomDistance.getAsDouble());
+                setpointVelocity = getSetpointVelocity(odometryDistance.getAsDouble());
             }
             if (RobotContainer.hardCodedVelocity) {
                 setpointVelocity = Constants.Shooter.TARMAC_VELOCITY;

--- a/src/main/java/frc/robot/subsystems/shooter/commands/Shoot.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/Shoot.java
@@ -12,6 +12,7 @@ import webapp.FireLog;
 
 import java.util.HashMap;
 import java.util.OptionalDouble;
+import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 
 public class Shoot extends CommandBase {
@@ -21,28 +22,34 @@ public class Shoot extends CommandBase {
     private final boolean bool;
     private final OptionalDouble power;
     private final Timer timer = new Timer();
+    private final BooleanSupplier hasTarget;
+    private final DoubleSupplier odomDistance;
     private double setpointVelocity = 0;
 
     public Shoot(Shooter shooter, Hood hood, double power) {
         this.shooter = shooter;
         this.hood = hood;
+        this.hasTarget = () -> true;
+        this.odomDistance = () -> 0;
         this.distance = () -> 8;
         this.power = OptionalDouble.of(power);
         bool = false;
         addRequirements(shooter);
     }
 
-    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, boolean bool) {
+    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, boolean bool, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
         this.shooter = shooter;
         this.hood = hood;
         this.distance = distance;
         this.bool = bool;
+        this.hasTarget = hasTarget;
+        this.odomDistance = odomDistance;
         this.power = OptionalDouble.empty();
         addRequirements(shooter);
     }
 
-    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance) {
-        this(shooter, hood, distance, false);
+    public Shoot(Shooter shooter, Hood hood, DoubleSupplier distance, BooleanSupplier hasTarget, DoubleSupplier odomDistance) {
+        this(shooter, hood, distance, false, hasTarget, odomDistance);
     }
 
     /**
@@ -52,9 +59,9 @@ public class Shoot extends CommandBase {
      * @param distance is the distance from the target. [m]
      * @return 15. [rpm]
      */
-    public static double getSetpointVelocity(double distance, boolean isShort) {
+    public static double getSetpointVelocity(double distance) {
         HashMap<Double, Double> measurements;
-        if (isShort) {
+        if (distance < Constants.Hood.DISTANCE_FROM_TARGET_THRESHOLD) {
             measurements = Constants.Shooter.SHORT_MEASUREMENTS;
         } else {
             measurements = Constants.Shooter.LONG_MEASUREMENTS;
@@ -89,7 +96,7 @@ public class Shoot extends CommandBase {
         timer.start();
         timer.reset();
         if (bool) {
-            setpointVelocity = getSetpointVelocity(distance.getAsDouble(), hood.isOpen());
+            setpointVelocity = getSetpointVelocity(distance.getAsDouble());
         } else {
             setpointVelocity = distance.getAsDouble();
         }

--- a/src/main/java/frc/robot/subsystems/shooter/commands/WarmUpShooter.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/WarmUpShooter.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.shooter.commands;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Constants;
 import frc.robot.subsystems.shooter.Shooter;
 
 import java.util.function.DoubleSupplier;
@@ -18,7 +17,7 @@ public class WarmUpShooter extends CommandBase {
     @Override
     public void execute() {
         double velocity = Shoot.getSetpointVelocity(
-                distanceFromTarget.getAsDouble(), distanceFromTarget.getAsDouble() < Constants.Hood.DISTANCE_FROM_TARGET_THRESHOLD);
+                distanceFromTarget.getAsDouble());
         shooter.setVelocity(velocity);
     }
 }

--- a/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckShooterAccuracy.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckShooterAccuracy.java
@@ -15,7 +15,7 @@ public class CheckShooterAccuracy extends Shoot {
     private double lastTime;
 
     public CheckShooterAccuracy(Shooter shooter, Hood hood, DoubleSupplier distance) {
-        super(shooter, hood, distance);
+        super(shooter, hood, distance, hasTarget, odomDistance);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckShooterAccuracy.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckShooterAccuracy.java
@@ -15,7 +15,7 @@ public class CheckShooterAccuracy extends Shoot {
     private double lastTime;
 
     public CheckShooterAccuracy(Shooter shooter, Hood hood, DoubleSupplier distance) {
-        super(shooter, hood, distance);
+        super(shooter, hood, distance, () -> true, () -> 0);
     }
 
     @Override
@@ -23,14 +23,14 @@ public class CheckShooterAccuracy extends Shoot {
         timer.reset();
         timer.start();
         lastTime = timer.get();
-        lastVelocity = getSetpointVelocity(distance.getAsDouble(), hood.isOpen());
+        lastVelocity = getSetpointVelocity(distance.getAsDouble());
     }
 
     @Override
     public void execute() {
         super.execute();
 
-        double setpoint = getSetpointVelocity(distance.getAsDouble(), hood.isOpen());
+        double setpoint = getSetpointVelocity(distance.getAsDouble());
         double currentVelocity = shooter.getVelocity();
         double acceleration = (currentVelocity - lastVelocity) / (timer.get() - lastTime);
 

--- a/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckVelocityDrop.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckVelocityDrop.java
@@ -12,7 +12,7 @@ public class CheckVelocityDrop extends Shoot {
     private double maximalDrop = 0;
 
     public CheckVelocityDrop(Shooter shooter, Hood hood, DoubleSupplier distance) {
-        super(shooter, hood, distance);
+        super(shooter, hood, distance, hasTarget, odomDistance);
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckVelocityDrop.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/bits/CheckVelocityDrop.java
@@ -12,14 +12,14 @@ public class CheckVelocityDrop extends Shoot {
     private double maximalDrop = 0;
 
     public CheckVelocityDrop(Shooter shooter, Hood hood, DoubleSupplier distance) {
-        super(shooter, hood, distance);
+        super(shooter, hood, distance, () -> true, () -> 0);
     }
 
     @Override
     public void execute() {
         super.execute();
         double velocity = shooter.getVelocity();
-        double setpoint = getSetpointVelocity(distance.getAsDouble(), hood.isOpen());
+        double setpoint = getSetpointVelocity(distance.getAsDouble());
         maximalDrop = Math.max(maximalDrop, lastVelocity - velocity);
 
         FireLog.log("Setpoint", setpoint);

--- a/src/main/java/frc/robot/subsystems/shooter/commands/bits/TryVelocities.java
+++ b/src/main/java/frc/robot/subsystems/shooter/commands/bits/TryVelocities.java
@@ -79,7 +79,7 @@ public class TryVelocities extends SequentialCommandGroup {
 
         addCommands(
                 new ShootCargo(shooter, hood, conveyor, flap,
-                        Constants.Conveyor.DEFAULT_POWER::get, () -> distanceFromTarget)
+                        Constants.Conveyor.DEFAULT_POWER::get, () -> distanceFromTarget, () -> true, () -> 0)
                         .withInterrupt(() -> getOutputs()[2]),
                 new WaitUntilCommand(isFinished).andThen(() -> {
                     if (getOutputs()[0]) {

--- a/src/main/java/frc/robot/utils/PhotonVisionModule.java
+++ b/src/main/java/frc/robot/utils/PhotonVisionModule.java
@@ -11,6 +11,7 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Ports;
 import frc.robot.Robot;
+import frc.robot.RobotContainer;
 import org.photonvision.PhotonCamera;
 import org.photonvision.PhotonUtils;
 import org.photonvision.SimPhotonCamera;
@@ -55,6 +56,10 @@ public class PhotonVisionModule extends SubsystemBase {
     public boolean hasTargets() {
         if (Robot.isSimulation()) {
             return simCamera.getLatestResult().hasTargets();
+        }
+
+        if (RobotContainer.playWithoutVision) {
+            return false;
         }
         return camera.getLatestResult().hasTargets();
     }

--- a/src/test/java/Lol.java
+++ b/src/test/java/Lol.java
@@ -1,2 +1,0 @@
-package PACKAGE_NAME;public class Lol {
-}

--- a/src/test/java/Test.java
+++ b/src/test/java/Test.java
@@ -1,18 +1,2 @@
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
-
 public class Test {
-    @org.junit.Test
-    public void test() {
-//        var robotAngle = Rotation2d.fromDegrees(0);
-//        var robotPose = new Translation2d(1, 1);
-//        var hubPose = new Translation2d(3, 3);
-//        var poseRelativeToTarget = hubPose.minus(robotPose);
-//        var value = robotAngle.minus(new Rotation2d(
-//                Math.atan2(
-//                        poseRelativeToTarget.getY(),
-//                        poseRelativeToTarget.getX()
-//                )));
-//        System.out.println(value.getDegrees());
-    }
 }

--- a/src/test/java/Test.java
+++ b/src/test/java/Test.java
@@ -1,0 +1,18 @@
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+
+public class Test {
+    @org.junit.Test
+    public void test() {
+//        var robotAngle = Rotation2d.fromDegrees(0);
+//        var robotPose = new Translation2d(1, 1);
+//        var hubPose = new Translation2d(3, 3);
+//        var poseRelativeToTarget = hubPose.minus(robotPose);
+//        var value = robotAngle.minus(new Rotation2d(
+//                Math.atan2(
+//                        poseRelativeToTarget.getY(),
+//                        poseRelativeToTarget.getX()
+//                )));
+//        System.out.println(value.getDegrees());
+    }
+}


### PR DESCRIPTION
Add vision safeties for competition.

Every Command gets a special case for when the vision can't see the target.

Adjust to target commands are switched to angle by odometry.

Shooting commands are switched to distance from odometry.

Also in auto.

Constant for whether or not we're playing without vision.